### PR TITLE
Add Inspect URL to PR-opened workflow using target_url

### DIFF
--- a/.github/workflows/comment-on-pr-about-deployment.yml
+++ b/.github/workflows/comment-on-pr-about-deployment.yml
@@ -42,7 +42,15 @@ jobs:
         run: |
           echo "state=${{ fromJSON(env.STATUS).state }}" >> $GITHUB_OUTPUT
           echo "url=${{ fromJSON(env.STATUS).environment_url }}" >> $GITHUB_OUTPUT
-          echo "inspect_url=${{ fromJSON(env.STATUS).target_url }}" >> $GITHUB_OUTPUT
+          
+          # descriptionからInspect URLを抽出
+          DESCRIPTION="${{ fromJSON(env.STATUS).description }}"
+          if [[ "$DESCRIPTION" == inspect:* ]]; then
+            INSPECT_URL="${DESCRIPTION#inspect:}"
+            echo "inspect_url=$INSPECT_URL" >> $GITHUB_OUTPUT
+          else
+            echo "inspect_url=" >> $GITHUB_OUTPUT
+          fi
         env:
           STATUS: ${{ toJSON(fromJSON(steps.get-statuses.outputs.statuses)[0]) }}
 

--- a/.github/workflows/comment-on-pr-about-deployment.yml
+++ b/.github/workflows/comment-on-pr-about-deployment.yml
@@ -42,15 +42,7 @@ jobs:
         run: |
           echo "state=${{ fromJSON(env.STATUS).state }}" >> $GITHUB_OUTPUT
           echo "url=${{ fromJSON(env.STATUS).environment_url }}" >> $GITHUB_OUTPUT
-          
-          # descriptionからInspect URLを抽出
-          DESCRIPTION="${{ fromJSON(env.STATUS).description }}"
-          if [[ "$DESCRIPTION" == *"Inspect:"* ]]; then
-            INSPECT_URL=$(echo "$DESCRIPTION" | grep -o 'Inspect: [^|]*' | sed 's/Inspect: //')
-            echo "inspect_url=$INSPECT_URL" >> $GITHUB_OUTPUT
-          else
-            echo "inspect_url=" >> $GITHUB_OUTPUT
-          fi
+          echo "inspect_url=${{ fromJSON(env.STATUS).target_url }}" >> $GITHUB_OUTPUT
         env:
           STATUS: ${{ toJSON(fromJSON(steps.get-statuses.outputs.statuses)[0]) }}
 
@@ -91,7 +83,7 @@ jobs:
           body: |
             ## 🚀 Preview Deployment
             
-            ✅ **Status**: Ready${{ needs.check-if-deployment-exists.outputs.inspect_url != '' && format(' ([Inspect]({0}))', needs.check-if-deployment-exists.outputs.inspect_url) || '' }}
+            ✅ **Status**: Ready${{ needs.check-if-deployment-exists.outputs.inspect_url && format(' ([Inspect]({0}))', needs.check-if-deployment-exists.outputs.inspect_url) || '' }}
             🔗 **Preview**: [Visit Preview](${{ needs.check-if-deployment-exists.outputs.url }})
             📝 **Branch**: `${{ github.head_ref }}`
             📅 **Updated**: ${{ steps.datetime.outputs.value }}

--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -82,8 +82,7 @@ jobs:
           env: ${{ steps.deployment.outputs.env }}
           env_url: ${{ steps.deploy-url.outputs.url }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          target_url: ${{ steps.deploy-url.outputs.inspect_url }}
-          desc: "Preview deployed"
+          desc: "inspect:${{ steps.deploy-url.outputs.inspect_url }}"
 
   check-if-pr-exists:
     needs: deploy

--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -82,6 +82,7 @@ jobs:
           env: ${{ steps.deployment.outputs.env }}
           env_url: ${{ steps.deploy-url.outputs.url }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          target_url: ${{ steps.deploy-url.outputs.inspect_url }}
           desc: "Preview deployed"
 
   check-if-pr-exists:


### PR DESCRIPTION
- Store Inspect URL in GitHub Deployments target_url field
- Extract target_url from deployment status in PR comment workflow
- Add conditional Inspect link display in PR-opened comments
- Simplify URL extraction logic by using standard deployment fields

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com)