### PR TITLE
Improve PR deployment comment format with table layout and dynamic project name

### DIFF
--- a/.github/workflows/comment-on-pr-about-deployment.yml
+++ b/.github/workflows/comment-on-pr-about-deployment.yml
@@ -93,9 +93,9 @@ jobs:
           body: |
             **Deploy to Vercel**
             
-            | Name | Status | Preview | Updated (JST) |
-            | :--- | :----- | :------ | :------------ |
-            | **vercel-ci-playground** | ✅ Ready${{ needs.check-if-deployment-exists.outputs.inspect_url && format(' ([Inspect]({0}))', needs.check-if-deployment-exists.outputs.inspect_url) || '' }} | [Visit Preview](${{ needs.check-if-deployment-exists.outputs.url }}) | ${{ steps.datetime.outputs.value }} |
+            | Name | Status | Preview | Latest Commit | Updated (JST) |
+            | :--- | :----- | :------ | :------------ | :------------ |
+            | **vercel-ci-playground** | ✅ Ready${{ needs.check-if-deployment-exists.outputs.inspect_url && format(' ([Inspect]({0}))', needs.check-if-deployment-exists.outputs.inspect_url) || '' }} | [Visit Preview](${{ needs.check-if-deployment-exists.outputs.url }}) | `${{ steps.datetime.outputs.short_sha }}` | ${{ steps.datetime.outputs.value }} |
           edit-mode: replace
 
       - name: Create comment if the deployment has not completed
@@ -107,9 +107,9 @@ jobs:
           body: |
             **Deploy to Vercel**
             
-            | Name | Status | Preview | Updated (JST) |
-            | :--- | :----- | :------ | :------------ |
-            | **vercel-ci-playground** | ⏳ In Progress | - | ${{ steps.datetime.outputs.value }} |
+            | Name | Status | Preview | Latest Commit | Updated (JST) |
+            | :--- | :----- | :------ | :------------ | :------------ |
+            | **vercel-ci-playground** | ⏳ In Progress | - | `${{ steps.datetime.outputs.short_sha }}` | ${{ steps.datetime.outputs.value }} |
           edit-mode: replace
 
       - name: Create comment if deployment is starting
@@ -120,6 +120,6 @@ jobs:
           body: |
             **Deploy to Vercel**
             
-            | Name | Status | Preview | Updated (JST) |
-            | :--- | :----- | :------ | :------------ |
-            | **vercel-ci-playground** | ⏳ Starting | - | ${{ steps.datetime.outputs.value }} |
+            | Name | Status | Preview | Latest Commit | Updated (JST) |
+            | :--- | :----- | :------ | :------------ | :------------ |
+            | **vercel-ci-playground** | ⏳ Starting | - | `${{ steps.datetime.outputs.short_sha }}` | ${{ steps.datetime.outputs.value }} |

--- a/.github/workflows/comment-on-pr-about-deployment.yml
+++ b/.github/workflows/comment-on-pr-about-deployment.yml
@@ -89,11 +89,10 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.fc.outputs.comment-id }}
           body: |
-            ## 🚀 Preview Deployment
+            ## 🚀 Preview Deployment - vercel-ci-playground
             
             ✅ **Status**: Ready${{ needs.check-if-deployment-exists.outputs.inspect_url && format(' ([Inspect]({0}))', needs.check-if-deployment-exists.outputs.inspect_url) || '' }}
             🔗 **Preview**: [Visit Preview](${{ needs.check-if-deployment-exists.outputs.url }})
-            📝 **Branch**: `${{ github.head_ref }}`
             📅 **Updated**: ${{ steps.datetime.outputs.value }}
             📋 **Commit**: `${{ steps.datetime.outputs.short_sha }}`
           edit-mode: replace
@@ -105,10 +104,9 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.fc.outputs.comment-id }}
           body: |
-            ## 🚀 Preview Deployment
+            ## 🚀 Preview Deployment - vercel-ci-playground
             
             ⏳ **Status**: In Progress
-            📝 **Branch**: `${{ github.head_ref }}`
             📅 **Updated**: ${{ steps.datetime.outputs.value }}
             📋 **Commit**: `${{ steps.datetime.outputs.short_sha }}`
           edit-mode: replace
@@ -119,9 +117,8 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ## 🚀 Preview Deployment
+            ## 🚀 Preview Deployment - vercel-ci-playground
             
             ⏳ **Status**: Starting
-            📝 **Branch**: `${{ github.head_ref }}`
             📅 **Updated**: ${{ steps.datetime.outputs.value }}
             📋 **Commit**: `${{ steps.datetime.outputs.short_sha }}`

--- a/.github/workflows/comment-on-pr-about-deployment.yml
+++ b/.github/workflows/comment-on-pr-about-deployment.yml
@@ -73,12 +73,14 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: github-actions[bot]
-          body-includes: Preview Deployment
+          body-includes: Deploy to Vercel
 
       - name: Get datetime for now
         id: datetime
         run: |
-          echo "value=$(date -u +'%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_OUTPUT
+          # JST (UTC+9) の時刻を取得
+          JST_TIME=$(TZ=Asia/Tokyo date +'%b %d, %Y %I:%M%p' | sed 's/AM/am/g; s/PM/pm/g')
+          echo "value=$JST_TIME" >> $GITHUB_OUTPUT
           SHORT_SHA="${{ github.event.pull_request.head.sha }}"
           echo "short_sha=${SHORT_SHA:0:7}" >> $GITHUB_OUTPUT
 
@@ -89,12 +91,11 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.fc.outputs.comment-id }}
           body: |
-            ## 🚀 Preview Deployment - vercel-ci-playground
+            **Deploy to Vercel**
             
-            ✅ **Status**: Ready${{ needs.check-if-deployment-exists.outputs.inspect_url && format(' ([Inspect]({0}))', needs.check-if-deployment-exists.outputs.inspect_url) || '' }}
-            🔗 **Preview**: [Visit Preview](${{ needs.check-if-deployment-exists.outputs.url }})
-            📅 **Updated**: ${{ steps.datetime.outputs.value }}
-            📋 **Commit**: `${{ steps.datetime.outputs.short_sha }}`
+            | Name | Status | Preview | Updated (JST) |
+            | :--- | :----- | :------ | :------------ |
+            | **vercel-ci-playground** | ✅ Ready${{ needs.check-if-deployment-exists.outputs.inspect_url && format(' ([Inspect]({0}))', needs.check-if-deployment-exists.outputs.inspect_url) || '' }} | [Visit Preview](${{ needs.check-if-deployment-exists.outputs.url }}) | ${{ steps.datetime.outputs.value }} |
           edit-mode: replace
 
       - name: Create comment if the deployment has not completed
@@ -104,11 +105,11 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-id: ${{ steps.fc.outputs.comment-id }}
           body: |
-            ## 🚀 Preview Deployment - vercel-ci-playground
+            **Deploy to Vercel**
             
-            ⏳ **Status**: In Progress
-            📅 **Updated**: ${{ steps.datetime.outputs.value }}
-            📋 **Commit**: `${{ steps.datetime.outputs.short_sha }}`
+            | Name | Status | Preview | Updated (JST) |
+            | :--- | :----- | :------ | :------------ |
+            | **vercel-ci-playground** | ⏳ In Progress | - | ${{ steps.datetime.outputs.value }} |
           edit-mode: replace
 
       - name: Create comment if deployment is starting
@@ -117,8 +118,8 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            ## 🚀 Preview Deployment - vercel-ci-playground
+            **Deploy to Vercel**
             
-            ⏳ **Status**: Starting
-            📅 **Updated**: ${{ steps.datetime.outputs.value }}
-            📋 **Commit**: `${{ steps.datetime.outputs.short_sha }}`
+            | Name | Status | Preview | Updated (JST) |
+            | :--- | :----- | :------ | :------------ |
+            | **vercel-ci-playground** | ⏳ Starting | - | ${{ steps.datetime.outputs.value }} |

--- a/.github/workflows/comment-on-pr-about-deployment.yml
+++ b/.github/workflows/comment-on-pr-about-deployment.yml
@@ -20,6 +20,7 @@ jobs:
       state: ${{ steps.get-status.outputs.state }}
       url: ${{ steps.get-status.outputs.url }}
       inspect_url: ${{ steps.get-status.outputs.inspect_url }}
+      project_name: ${{ steps.get-status.outputs.project_name }}
     steps:
       - name: Get associated deployments
         id: get-deployments
@@ -43,13 +44,19 @@ jobs:
           echo "state=${{ fromJSON(env.STATUS).state }}" >> $GITHUB_OUTPUT
           echo "url=${{ fromJSON(env.STATUS).environment_url }}" >> $GITHUB_OUTPUT
           
-          # descriptionからInspect URLを抽出
+          # descriptionからInspect URLとプロジェクト名を抽出
           DESCRIPTION="${{ fromJSON(env.STATUS).description }}"
           if [[ "$DESCRIPTION" == inspect:* ]]; then
-            INSPECT_URL="${DESCRIPTION#inspect:}"
+            # Inspect URL抽出: inspect:URL|project:NAME 形式から URL部分を取得
+            INSPECT_URL=$(echo "$DESCRIPTION" | sed 's/inspect:\([^|]*\).*/\1/' || echo "")
             echo "inspect_url=$INSPECT_URL" >> $GITHUB_OUTPUT
+            
+            # プロジェクト名抽出: project:NAME 部分から NAME を取得
+            PROJECT_NAME=$(echo "$DESCRIPTION" | sed 's/.*|project:\([^|]*\).*/\1/' || echo "${{ github.event.repository.name }}")
+            echo "project_name=$PROJECT_NAME" >> $GITHUB_OUTPUT
           else
             echo "inspect_url=" >> $GITHUB_OUTPUT
+            echo "project_name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
           fi
         env:
           STATUS: ${{ toJSON(fromJSON(steps.get-statuses.outputs.statuses)[0]) }}
@@ -95,7 +102,7 @@ jobs:
             
             | Name | Status | Preview | Latest Commit | Updated (JST) |
             | :--- | :----- | :------ | :------------ | :------------ |
-            | **vercel-ci-playground** | ✅ Ready${{ needs.check-if-deployment-exists.outputs.inspect_url && format(' ([Inspect]({0}))', needs.check-if-deployment-exists.outputs.inspect_url) || '' }} | [Visit Preview](${{ needs.check-if-deployment-exists.outputs.url }}) | `${{ steps.datetime.outputs.short_sha }}` | ${{ steps.datetime.outputs.value }} |
+            | **${{ needs.check-if-deployment-exists.outputs.project_name }}** | ✅ Ready${{ needs.check-if-deployment-exists.outputs.inspect_url && format(' ([Inspect]({0}))', needs.check-if-deployment-exists.outputs.inspect_url) || '' }} | [Visit Preview](${{ needs.check-if-deployment-exists.outputs.url }}) | `${{ steps.datetime.outputs.short_sha }}` | ${{ steps.datetime.outputs.value }} |
           edit-mode: replace
 
       - name: Create comment if the deployment has not completed
@@ -109,7 +116,7 @@ jobs:
             
             | Name | Status | Preview | Latest Commit | Updated (JST) |
             | :--- | :----- | :------ | :------------ | :------------ |
-            | **vercel-ci-playground** | ⏳ In Progress | - | `${{ steps.datetime.outputs.short_sha }}` | ${{ steps.datetime.outputs.value }} |
+            | **${{ needs.check-if-deployment-exists.outputs.project_name }}** | ⏳ In Progress | - | `${{ steps.datetime.outputs.short_sha }}` | ${{ steps.datetime.outputs.value }} |
           edit-mode: replace
 
       - name: Create comment if deployment is starting
@@ -122,4 +129,4 @@ jobs:
             
             | Name | Status | Preview | Latest Commit | Updated (JST) |
             | :--- | :----- | :------ | :------------ | :------------ |
-            | **vercel-ci-playground** | ⏳ Starting | - | `${{ steps.datetime.outputs.short_sha }}` | ${{ steps.datetime.outputs.value }} |
+            | **${{ needs.check-if-deployment-exists.outputs.project_name }}** | ⏳ Starting | - | `${{ steps.datetime.outputs.short_sha }}` | ${{ steps.datetime.outputs.value }} |

--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -141,12 +141,14 @@ jobs:
         with:
           issue-number: ${{ needs.check-if-pr-exists.outputs.pr-number }}
           comment-author: github-actions[bot]
-          body-includes: Preview Deployment
+          body-includes: Deploy to Vercel
 
       - name: Get datetime for now
         id: datetime
         run: |
-          echo "value=$(date -u +'%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_OUTPUT
+          # JST (UTC+9) の時刻を取得
+          JST_TIME=$(TZ=Asia/Tokyo date +'%b %d, %Y %I:%M%p' | sed 's/AM/am/g; s/PM/pm/g')
+          echo "value=$JST_TIME" >> $GITHUB_OUTPUT
           echo "short_sha=${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
 
       - name: Create or update comment
@@ -155,10 +157,9 @@ jobs:
           issue-number: ${{ needs.check-if-pr-exists.outputs.pr-number }}
           comment-id: ${{ steps.fc.outputs.comment-id }}
           body: |
-            ## 🚀 Preview Deployment - ${{ needs.deploy.outputs.project_name }}
+            **Deploy to Vercel**
             
-            ✅ **Status**: Ready ([Inspect](${{ needs.deploy.outputs.inspect_url }}))
-            🔗 **Preview**: [Visit Preview](${{ needs.deploy.outputs.url }})
-            📅 **Updated**: ${{ steps.datetime.outputs.value }}
-            📋 **Commit**: `${{ steps.datetime.outputs.short_sha }}`
+            | Name | Status | Preview | Updated (JST) |
+            | :--- | :----- | :------ | :------------ |
+            | **${{ needs.deploy.outputs.project_name }}** | ✅ Ready ([Inspect](${{ needs.deploy.outputs.inspect_url }})) | [Visit Preview](${{ needs.deploy.outputs.url }}) | ${{ steps.datetime.outputs.value }} |
           edit-mode: replace

--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -21,6 +21,7 @@ jobs:
     outputs:
       url: ${{ steps.deploy-url.outputs.url }}
       inspect_url: ${{ steps.deploy-url.outputs.inspect_url }}
+      project_name: ${{ steps.deploy-url.outputs.project_name }}
     steps:
       - name: Start deployment
         uses: bobheadxi/deployments@v1
@@ -66,11 +67,16 @@ jobs:
           # Inspect URL抽出 
           INSPECT_URL=$(cat deploy_output.txt | grep "Inspect:" | sed 's/.*Inspect: \(https:\/\/vercel\.com\/[^[:space:]]*\).*/\1/' || true)
           
+          # プロジェクト名抽出
+          PROJECT_NAME=$(cat deploy_output.txt | grep "To deploy to production" | sed 's/.*(\([^)]*\)\.vercel\.app).*/\1/' || true)
+          
           echo "Preview URL: $PREVIEW_URL"
           echo "Inspect URL: $INSPECT_URL"
+          echo "Project Name: $PROJECT_NAME"
           
           echo "url=$PREVIEW_URL" >> $GITHUB_OUTPUT
           echo "inspect_url=$INSPECT_URL" >> $GITHUB_OUTPUT
+          echo "project_name=$PROJECT_NAME" >> $GITHUB_OUTPUT
 
       - name: Update deployment status
         uses: bobheadxi/deployments@v1
@@ -149,11 +155,10 @@ jobs:
           issue-number: ${{ needs.check-if-pr-exists.outputs.pr-number }}
           comment-id: ${{ steps.fc.outputs.comment-id }}
           body: |
-            ## 🚀 Preview Deployment
+            ## 🚀 Preview Deployment - ${{ needs.deploy.outputs.project_name }}
             
             ✅ **Status**: Ready ([Inspect](${{ needs.deploy.outputs.inspect_url }}))
             🔗 **Preview**: [Visit Preview](${{ needs.deploy.outputs.url }})
-            📝 **Branch**: `${{ github.ref_name }}`
             📅 **Updated**: ${{ steps.datetime.outputs.value }}
             📋 **Commit**: `${{ steps.datetime.outputs.short_sha }}`
           edit-mode: replace

--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -159,7 +159,7 @@ jobs:
           body: |
             **Deploy to Vercel**
             
-            | Name | Status | Preview | Updated (JST) |
-            | :--- | :----- | :------ | :------------ |
-            | **${{ needs.deploy.outputs.project_name }}** | ✅ Ready ([Inspect](${{ needs.deploy.outputs.inspect_url }})) | [Visit Preview](${{ needs.deploy.outputs.url }}) | ${{ steps.datetime.outputs.value }} |
+            | Name | Status | Preview | Latest Commit | Updated (JST) |
+            | :--- | :----- | :------ | :------------ | :------------ |
+            | **${{ needs.deploy.outputs.project_name }}** | ✅ Ready ([Inspect](${{ needs.deploy.outputs.inspect_url }})) | [Visit Preview](${{ needs.deploy.outputs.url }}) | `${{ steps.datetime.outputs.short_sha }}` | ${{ steps.datetime.outputs.value }} |
           edit-mode: replace

--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -88,7 +88,7 @@ jobs:
           env: ${{ steps.deployment.outputs.env }}
           env_url: ${{ steps.deploy-url.outputs.url }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          desc: "inspect:${{ steps.deploy-url.outputs.inspect_url }}"
+          desc: "inspect:${{ steps.deploy-url.outputs.inspect_url }}|project:${{ steps.deploy-url.outputs.project_name }}"
 
   check-if-pr-exists:
     needs: deploy


### PR DESCRIPTION
## Summary
- Convert PR deployment comments to clean table format with JST timezone
- Add Latest Commit column showing commit hash
- Remove hardcoded project names by sharing data between workflows

## Changes
- **Table format**: Clean Markdown table instead of bullet points
- **JST timezone**: Display time in Japan timezone (`Jun 29, 2025 2:34am` format)
- **Latest Commit**: Add commit hash column for easy identification
- **Dynamic project name**: Extract project name from Vercel deployment and share between workflows
- **Data sharing**: Use GitHub Deployments description field to pass project name from `vercel-preview-deploy.yml` to `comment-on-pr-about-deployment.yml`

## Example output
```
**Deploy to Vercel**

| Name | Status | Preview | Latest Commit | Updated (JST) |
| :--- | :----- | :------ | :------------ | :------------ |
| **vercel-ci-playground** | ✅ Ready ([Inspect](url)) | [Visit Preview](url) | `a1b2c3d` | Jun 29, 2025 2:34am |
```

🤖 Generated with [Claude Code](https://claude.ai/code)