### PR TITLE
Add Vercel CLI caching to preview deployment workflow

### DIFF
--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -50,6 +50,14 @@ jobs:
       - name: Install Vercel CLI
         run: pnpm add -g vercel@latest
 
+      - name: Cache Vercel CLI
+        uses: actions/cache@v4
+        with:
+          path: ~/.vercel
+          key: vercel-${{ runner.os }}-${{ hashFiles('**/vercel.json', '**/package.json') }}
+          restore-keys: |
+            vercel-${{ runner.os }}-
+
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
         continue-on-error: false


### PR DESCRIPTION
## Summary
- Add Vercel CLI caching to preview deployment workflow for consistency and performance

## Changes Made
- Cache `~/.vercel` directory to improve build performance
- Use same caching strategy as production workflow (package.json + vercel.json hash)
- Reduces deployment time by reusing Vercel configuration

## Benefits
- Faster preview deployments through configuration reuse
- Consistent caching approach across all deployment workflows
- Reduced API calls to Vercel during deployment process

## Test plan
- [x] Verify preview workflow runs successfully with caching
- [x] Confirm cache is created and reused in subsequent runs
- [x] Test deployment time improvement

🤖 Generated with [Claude Code](https://claude.ai/code)